### PR TITLE
Fix: hover effect on tap left/right

### DIFF
--- a/src/styles.module.css
+++ b/src/styles.module.css
@@ -72,6 +72,12 @@
   opacity: 1;
 }
 
+@media (hover: none) {
+  .navigation:hover {
+    opacity: 0.2;
+  }
+}
+
 .prev {
   left: 0;
 }


### PR DESCRIPTION
Currently hover effect gets stuck when tapped left or right. This change removes it on tap event. This is exactly that MUI do with their buttons.